### PR TITLE
Fix/core sum

### DIFF
--- a/common/changes/@monorepo/core/fix-core-sum_2020-07-29-10-23.json
+++ b/common/changes/@monorepo/core/fix-core-sum_2020-07-29-10-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@monorepo/core",
+      "comment": "Removed bug in sum function",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@monorepo/core",
+  "email": "kiers.bas@gmail.com"
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,7 @@ export interface Example {
 }
 
 export function sum(a: number, b: number) {
-  return a + b + 5;
+  return a + b;
 }
 
 export function krijtje(s: string) {


### PR DESCRIPTION
This change, including the file in `common/changes` creates the ability to publish new versions using `rush publish`

Example of `rush publish`:
```
Rush Multi-Project Build Tool 5.23.2 - https://rushjs.io
Node.js version is 10.22.0 (LTS)


Starting "rush publish"

Validating package manager shrinkwrap file.

Finding changes in: /home/baskiers/schiphol/monorepo-example/common/changes

* DRYRUN: git checkout -b publish-1596018351713

* DRYRUN: minor update for @monorepo/core to 1.1.0
 - [minor] Removed bug in sum function

* DRYRUN: patch update for @monorepo/processor to 1.0.1
 - [dependency] Updating dependency "@monorepo/core" from `1.0.0` to `1.1.0`

* DRYRUN: Changelog update for "@monorepo/core@1.1.0".

* DRYRUN: Changelog update for "@monorepo/processor@1.0.1".

* DRYRUN: Deleting 1 change file(s).
 - /home/baskiers/schiphol/monorepo-example/common/changes/@monorepo/core/fix-core-sum_2020-07-29-10-23.json

* DRYRUN: git checkout undefined

* DRYRUN: git branch -d publish-1596018351713

Rush publish finished successfully.
```